### PR TITLE
Install colors as a production dependency, not development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -730,10 +730,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
-      "dev": true
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "combined-stream": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "axios": "^0.19.0",
     "btcpay": "github:btcpayserver/node-btcpay",
+    "colors": "^1.4.0",
     "cors": "^2.8.5",
     "dotenv": "^6.2.0",
     "express": "4.16.3",
@@ -42,7 +43,6 @@
     "@types/nodemailer": "^4.6.6",
     "@typescript-eslint/parser": "1.9.0",
     "chai": "^4.2.0",
-    "colors": "^1.3.2",
     "eslint": "5.16.0",
     "eslint-config-airbnb-base": "13.1.0",
     "eslint-plugin-import": "2.17.3",


### PR DESCRIPTION
This was crashing the app in production because the module was missing