### PR TITLE
Fix BTCPay webhook not returning response

### DIFF
--- a/app/routes/accounts/mastodon/btcpay_hook.ts
+++ b/app/routes/accounts/mastodon/btcpay_hook.ts
@@ -36,13 +36,15 @@ class MastodonBtcPayHookRoute extends BaseRoute {
       content: message
     }).then(() => res.status(200))
       .catch(err => this.handleError(res, err))
+
+    return res.status(200).json({ status: 'OK' })
   }
 
   private createMessage (inviteCode: String) {
     const inviteUrl = `${process.env.MASTODON_HOST}/invite/${inviteCode}`
     const message = 'Here\'s your invite link for creating an account on kosmos.social:'
                   + `\n\n${inviteUrl}\n\n`
-                  + 'Thanks a lot for supporting community service providers!'
+                  + 'Welcome to the community!'
     return message
   }
 

--- a/spec/routes/accounts/mastodon/btcpay_hook.spec.ts
+++ b/spec/routes/accounts/mastodon/btcpay_hook.spec.ts
@@ -49,7 +49,7 @@ describe('POST /accounts/mastodon/btcpay_hook', () => {
         })
     })
 
-    it('returns an error', async () => {
+    it('returns a 200', async () => {
       await supertest
         .post('/accounts/mastodon/btcpay_hook?token=supersecure')
         .set('Content-Type', 'application/json')


### PR DESCRIPTION
Adds a test for successful Webhook responses and fixes the missing return.